### PR TITLE
Multiple configs, event pre-processor, restore deleted gcal entires, bug fixes, sync history

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,18 @@ I've been running this script on an RPi as a cronjob and it's working well for m
 > NOTE: requires Python 3.7+ (2.7 can be made to work to some extent, but hasn't been well-tested recently and you may encounter bugs)
 
 Some brief instructions:
-1. Edit config.py and set ICAL_FEED to the URL of the iCal feed you want to sync events from.
-2. Set CALENDAR_ID to the ID of the Google Calendar instance you want to insert events into. You can set it to "primary" to use the default main calendar, or create a new secondary calendar (in which case you can find the ID on the settings page, of the form 'longID@group.calendar.google.com').
-3. pip install -r requirements.txt
-4. Go through the process of registering an app in the Google Calendar API dashboard in order to obtain the necessary API credentials. This process is described at https://developers.google.com/google-apps/calendar/quickstart/python - rename the downloaded file to ical_to_gcal_sync_client_secret.json and place it in the same location as the script. 
-5. Run the script. This should trigger the OAuth2 authentication process and prompt you to allow the app you created in step 4 to access your calendars. If successful it should store the credentials in ical_to_gcal_sync.json.
-6. Subsequent runs of the script should not require any further interaction unless the credentials are invalidated/changed.
+1. Edit config.py or copy to new file (see *Multiple Configurations* below)
+2. Set ICAL_FEED to the URL of the iCal feed you want to sync events from.
+3. Set CALENDAR_ID to the ID of the Google Calendar instance you want to insert events into. You can set it to "primary" to use the default main calendar, or create a new secondary calendar (in which case you can find the ID on the settings page, of the form 'longID@group.calendar.google.com').
+4. pip install -r requirements.txt
+5. Go through the process of registering an app in the Google Calendar API dashboard in order to obtain the necessary API credentials. This process is described at https://developers.google.com/google-apps/calendar/quickstart/python - rename the downloaded file to ical_to_gcal_sync_client_secret.json and place it in the same location as the script. 
+6. Run the script. This should trigger the OAuth2 authentication process and prompt you to allow the app you created in step 4 to access your calendars. If successful it should store the credentials in ical_to_gcal_sync.json.
+7. Subsequent runs of the script should not require any further interaction unless the credentials are invalidated/changed.
+
+## Multiple Configurations / Alternate Config Location
+
+If you want to specify an alternate location for the config.py file, use the environment variable CONFIG_PATH:
+
+```
+CONFIG_PATH='/path/to/my-custom-config.py' python ical_to_gcal_sync.py
+```

--- a/README.md
+++ b/README.md
@@ -24,3 +24,33 @@ If you want to specify an alternate location for the config.py file, use the env
 ```
 CONFIG_PATH='/path/to/my-custom-config.py' python ical_to_gcal_sync.py
 ```
+
+## Rewriting Events / Skipping Events
+
+If you specify a function in the config file called EVENT_PREPROESSOR, you can use that
+function to rewrite or even skip events from being synced to the Google Calendar.
+
+Some example rewrite rules:
+
+``` python
+import icalevents
+def EVENT_PREPROCESSOR(ev: icalevents.icalparser.Event) -> bool:
+    from datetime import timedelta
+
+    # Skip Bob's out of office messages
+    if ev.summary == "Bob OOO":
+        return False
+
+    # Skip gaming events when we're playing Monopoly
+    if ev.summary == "Gaming" and "Monopoly" in ev.description:
+        return False
+
+    # convert fire drill events to all-day events
+    if ev.summary == "Fire Drill":
+        ev.all_day = True
+        ev.start = ev.start.replace(hour=0, minute=0, second=0)
+        ev.end = ev.start + timedelta(days=1)
+
+    # include all other entries
+    return True
+```

--- a/auth.py
+++ b/auth.py
@@ -5,33 +5,31 @@ from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 
-from config import CREDENTIAL_PATH, CLIENT_SECRET_FILE, SCOPES
-
-def auth_with_calendar_api():
+def auth_with_calendar_api(config):
     creds = None
 
     # this file stores your access and refresh tokens, and is
     # created automatically when the auth flow succeeeds for 
     # the first time. 
-    if os.path.exists(CREDENTIAL_PATH):
+    if os.path.exists(config['CREDENTIAL_PATH']):
         # if credentials file fails to load (e.g. because it's the old
         # style JSON content instead), just delete it
         try:
-            with open(CREDENTIAL_PATH, 'rb') as token:
+            with open(config['CREDENTIAL_PATH'], 'rb') as token:
                 creds = pickle.load(token)
         except Exception as err:
-            os.unlink(CREDENTIAL_PATH)
+            os.unlink(config['CREDENTIAL_PATH'])
 
     if not creds or not creds.valid:
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(CLIENT_SECRET_FILE,
-                                                             [SCOPES])
+            flow = InstalledAppFlow.from_client_secrets_file(config['CLIENT_SECRET_FILE'],
+                                                             [config['SCOPES']])
             creds = flow.run_console() # or run_local_server(port=0)
 
         # save credentials if successful
-        with open(CREDENTIAL_PATH, 'wb') as token:
+        with open(config['CREDENTIAL_PATH'], 'wb') as token:
             pickle.dump(creds, token)
 
     service = build('calendar', 'v3', credentials=creds)

--- a/config.py
+++ b/config.py
@@ -56,3 +56,16 @@ PAST_DAYS_TO_SYNC = 30
 # will be restored by this script - otherwise they will be left deleted, but will
 # be updated - just Google won't show them
 RESTORE_DELETED_EVENTS = True
+
+# function to modify events coming from the ical source before they get compared
+# to the Google Calendar entries and inserted/deleted
+#
+# this function should modify the events in-place and return either True (keep) or
+# False (delete/skip) the event from the Calendar. If this returns False on an event
+# that is already in the Google Calendar, the event will be deleted from the Google
+# Calendar
+import icalevents
+def EVENT_PREPROCESSOR(ev: icalevents.icalparser.Event) -> bool:
+    # include all entries by default
+    # see README.md for examples of rules that make changes/skip
+    return True

--- a/config.py
+++ b/config.py
@@ -40,3 +40,13 @@ API_SLEEP_TIME = 0.10
 # actually be equivalent to "all events up to a year from now" (to sync events
 # further into the future than that, set a sufficiently high number of days).
 ICAL_DAYS_TO_SYNC = 0
+
+# Integer value >= 0
+# Controls how many days in the past to query/update from Google and the ical source.
+# If you want to only worry about today's events and future events, set to 0,
+# otherwise set to a positive number (e.g. 30) to include that many days in the past.
+# Any events outside of that time-range will be untouched in the Google Calendar.
+# If the ical source doesn't include historical events, then this will mean deleting
+# a rolling number of days historical calendar entries from Google Calendar as the script
+# runs
+PAST_DAYS_TO_SYNC = 30

--- a/config.py
+++ b/config.py
@@ -50,3 +50,9 @@ ICAL_DAYS_TO_SYNC = 0
 # a rolling number of days historical calendar entries from Google Calendar as the script
 # runs
 PAST_DAYS_TO_SYNC = 30
+
+# Restore deleted events
+# If this is set to True, then events that have been deleted from the Google Calendar
+# will be restored by this script - otherwise they will be left deleted, but will
+# be updated - just Google won't show them
+RESTORE_DELETED_EVENTS = True

--- a/config.py
+++ b/config.py
@@ -1,28 +1,28 @@
 # The iCal feed URL for the events that should be synced to the Google Calendar.
 # Note that the syncing is one-way only.
 # If FILES is True then ICAL_FEED is the path to a folder full of ics files.
-ICAL_FEED = '<ICAL FEED URL>'
+ICAL_FEED = ''
 FILES = False
 
 # the ID of the calendar to use for iCal events, should be of the form
 # 'ID@group.calendar.google.com', check the calendar settings page to find it.
 # (can also be 'primary' to use the default calendar)
-CALENDAR_ID = '<GOOGLE CALENDAR ID>'
+CALENDAR_ID = '<GOOGLE_CALENDAR_ID@group.calendar.google.com>'
 
 # must use the OAuth scope that allows write access
 SCOPES = 'https://www.googleapis.com/auth/calendar'
 
 # API secret stored in this file
-CLIENT_SECRET_FILE = 'ical_to_gcal_sync_client_secret.json'
+CLIENT_SECRET_FILE = '<CLIENT_SECRET_FILE.json>'
 
 # Location to store API credentials
-CREDENTIAL_PATH = 'ical_to_gcal_sync.pckl'
+CREDENTIAL_PATH = '<CREDENTIALS_PATH.pckl>'
 
 # Application name for the Google Calendar API
 APPLICATION_NAME = 'ical_to_gcal_sync'
 
 # File to use for logging output
-LOGFILE = 'ical_to_gcal_sync_log.txt'
+LOGFILE = '<LOG_FILE_PATH.log>'
 
 # Time to pause between successive API calls that may trigger rate-limiting protection
 API_SLEEP_TIME = 0.10

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -332,5 +332,7 @@ if __name__ == '__main__':
                 service.events().insert(calendarId=config['CALENDAR_ID'], body=gcal_event).execute()
             except:
                 time.sleep(config['API_SLEEP_TIME'])
-                service.events().update(calendarId=config['CALENDAR_ID'], eventId=gcal_event['id'], body=gcal_event).execute()
-                
+                try:
+                    service.events().update(calendarId=config['CALENDAR_ID'], eventId=gcal_event['id'], body=gcal_event).execute()
+                except Exception as ex:
+                    logger.error("Error updating: %s (%s)" % ( gcal_event['id'], ex ) )

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -233,6 +233,9 @@ if __name__ == '__main__':
             # your calendar, selecting "View bin" and then clicking "Empty bin 
             # now" to completely delete these events.
             try:
+                # already marked as deleted, so it's in the "trash" or "bin"
+                if gcal_event['status'] == 'cancelled': continue
+
                 logger.info(u'> Deleting event "{}" from Google Calendar...'.format(gcal_event.get('summary', '<unnamed event>')))
                 service.events().delete(calendarId=config['CALENDAR_ID'], eventId=eid).execute()
                 time.sleep(config['API_SLEEP_TIME'])

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -197,6 +197,16 @@ if __name__ == '__main__':
         if ev.end is not None and ev.end.tzinfo is None:
             ev.end = ev.end.replace(tzinfo=timezone.utc)
 
+        try:
+            if 'EVENT_PREPROCESSOR' in config:
+                keep = config['EVENT_PREPROCESSOR'](ev)
+                if not keep: 
+                    logger.debug("Skipping event %s - EVENT_PREPROCESSOR returned false" % (str(ev)))
+                    continue
+
+        except Exception as ex:
+            logger.error("Error processing entry (%s) - leaving as-is" % str(ev))
+
         ical_events[create_id(ev.uid, ev.start, ev.end)] = ev
 
     logger.debug('> Collected {:d} iCal events'.format(len(ical_events)))

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -233,8 +233,8 @@ if __name__ == '__main__':
             gcal_begin = arrow.get(gcal_event['start'].get('dateTime', gcal_event['start'].get('date')))
             gcal_end = arrow.get(gcal_event['end'].get('dateTime', gcal_event['end'].get('date')))
 
-            gcal_has_location = 'location' in gcal_event
-            ical_has_location = ical_event.location is not None
+            gcal_has_location = bool(gcal_event.get('location'))
+            ical_has_location = bool(ical_event.location)
 
             gcal_has_description = 'description' in gcal_event
             ical_has_description = ical_event.description is not None
@@ -243,17 +243,21 @@ if __name__ == '__main__':
             gcal_name = gcal_event.get('summary', None)
             log_name = '<unnamed event>' if gcal_name is None else gcal_name
 
+            times_differ = gcal_begin != ical_event.start or gcal_end != ical_event.end
+            titles_differ = gcal_name != ical_event.summary
+            locs_differ = gcal_has_location != ical_has_location and gcal_event.get('location') != ical_event.location
+            descs_differ = gcal_has_description != ical_has_description and (gcal_event.get('description') != ical_event.description)
+
+            changes = []
+            if times_differ: changes.append("start/end times")
+            if titles_differ: changes.append("titles")
+            if locs_differ: changes.append("locations")
+            if descs_differ: changes.append("descriptions")
+
             # check if the iCal event has a different: start/end time, name, location,
             # or description, and if so sync the changes to the GCal event
-            if gcal_begin != ical_event.start\
-                or gcal_end != ical_event.end\
-                or gcal_name != ical_event.summary\
-                or gcal_has_location != ical_has_location \
-                or (gcal_has_location and gcal_event['location'] != ical_event.location) \
-                or gcal_has_description != ical_has_description \
-                or (gcal_has_description and gcal_event['description'] != ical_event.description):
-
-                logger.info(u'> Updating event "{}" due to date/time change...'.format(log_name))
+            if times_differ or titles_differ or locs_differ or descs_differ:
+                logger.info(u'> Updating event "{}" due to changes: {}'.format(log_name, ", ".join(changes)))
                 delta = ical_event.end - ical_event.start
                 # all-day events handled slightly differently
                 # TODO multi-day events?

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -5,7 +5,7 @@ import time
 import string
 import re
 import sys
-#import pickle
+import os
 
 import googleapiclient
 import arrow
@@ -15,16 +15,21 @@ from dateutil.tz import gettz
 from datetime import datetime, timezone, timedelta
 
 from auth import auth_with_calendar_api
-from config import ICAL_FEED, FILES, CALENDAR_ID, API_SLEEP_TIME, ICAL_DAYS_TO_SYNC, LOGFILE
+from pathlib import Path
+config = {}
+config_path=os.environ.get('CONFIG_PATH', 'config.py')
+exec(Path(config_path).read_text(), config)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-handler = logging.FileHandler(filename=LOGFILE, mode='a')
+if config.get('LOGFILE', None):
+    handler = logging.FileHandler(filename=config['LOGFILE'], mode='a')
+else:
+    handler = logging.StreamHandler(sys.stderr)
 handler.setFormatter(logging.Formatter('%(asctime)s|[%(levelname)s] %(message)s'))
 logger.addHandler(handler)
 
 DEFAULT_TIMEDELTA = timedelta(days=365)
-
 
 def get_current_events_from_files():
     
@@ -38,9 +43,9 @@ def get_current_events_from_files():
     from glob import glob
     from os.path import join
 
-    event_ics = glob(join(ICAL_FEED, '*.ics'))
+    event_ics = glob(join(config['ICAL_FEED'], '*.ics'))
 
-    logger.debug('> Found {} local .ics files in {}'.format(len(event_ics), join(ICAL_FEED, '*.ics')))
+    logger.debug('> Found {} local .ics files in {}'.format(len(event_ics), join(config['ICAL_FEED'], '*.ics')))
     if len(event_ics) > 0:
         ics = event_ics[0]
         logger.debug('> Loading file {}'.format(ics))
@@ -64,15 +69,15 @@ def get_current_events(feed):
     """
 
     events_end = datetime.now()
-    if ICAL_DAYS_TO_SYNC == 0:
+    if config['ICAL_DAYS_TO_SYNC'] == 0:
         # default to 1 year ahead
         events_end += DEFAULT_TIMEDELTA
     else:
         # add on a number of days
-        events_end += timedelta(days=ICAL_DAYS_TO_SYNC)
+        events_end += timedelta(days=config['ICAL_DAYS_TO_SYNC'])
 
     try:
-        if FILES:
+        if config['FILES']:
             cal = events(file=feed, end=events_end)
         else:
             cal = events(feed, end=events_end)
@@ -97,7 +102,7 @@ def get_gcal_events(service, from_time):
     logger.debug('Retrieving Google Calendar events')
 
     # make an initial call, if this returns all events we don't need to do anything else,,,
-    eventsResult = service.events().list(calendarId=CALENDAR_ID, 
+    eventsResult = service.events().list(calendarId=config['CALENDAR_ID'], 
                                          timeMin=from_time, 
                                          singleEvents=True, 
                                          orderBy='startTime', 
@@ -112,7 +117,7 @@ def get_gcal_events(service, from_time):
     # otherwise keep calling the method, passing back the nextPageToken each time
     while 'nextPageToken' in eventsResult:
         token = eventsResult['nextPageToken']
-        eventsResult = service.events().list(calendarId=CALENDAR_ID, 
+        eventsResult = service.events().list(calendarId=config['CALENDAR_ID'], 
                                              timeMin=from_time, 
                                              pageToken=token, 
                                              singleEvents=True, 
@@ -128,8 +133,8 @@ def get_gcal_events(service, from_time):
 def delete_all_events(service):
     for gc in get_gcal_events(service):
         try:
-            service.events().delete(calendarId=CALENDAR_ID, eventId=gc['id']).execute()
-            time.sleep(API_SLEEP_TIME)
+            service.events().delete(calendarId=config['CALENDAR_ID'], eventId=gc['id']).execute()
+            time.sleep(config['API_SLEEP_TIME'])
         except googleapiclient.errors.HttpError:
             pass # event already marked as deleted
 
@@ -154,9 +159,15 @@ def create_id(uid, begintime, endtime):
     return re.sub('[^{}]'.format(allowed_chars), '', uid.lower()) + str(arrow.get(begintime).timestamp) + str(arrow.get(endtime).timestamp)
 
 if __name__ == '__main__':
+    mandatory_configs = ['CALENDAR_ID', 'CREDENTIAL_PATH', 'ICAL_FEED', 'APPLICATION_NAME']
+    for mandatory in mandatory_configs:
+        if not config.get(mandatory) or config[mandatory][0] == '<':
+            logger.error("Must specify a non-blank value for %s in the config file" % ( mandatory ) )
+            sys.exit(1)
+
     # setting up Google Calendar API for use
     logger.debug('> Loading credentials')
-    service = auth_with_calendar_api()
+    service = auth_with_calendar_api(config)
 
     # dateime instance representing the start of the current day (UTC)
     today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
@@ -164,14 +175,14 @@ if __name__ == '__main__':
     # retrieve events from Google Calendar, starting from beginning of current day
     logger.info('> Retrieving events from Google Calendar')
     gcal_events = get_gcal_events(service, today.isoformat())
-
+    
     # retrieve events from the iCal feed
-    if FILES:
+    if config['FILES']:
         logger.info('> Retrieving events from local folder')
         ical_cal = get_current_events_from_files()
     else:
         logger.info('> Retrieving events from iCal feed')
-        ical_cal = get_current_events(ICAL_FEED)
+        ical_cal = get_current_events(config['ICAL_FEED'])
 
     if ical_cal is None:
         sys.exit(-1)
@@ -192,7 +203,7 @@ if __name__ == '__main__':
     logger.debug('> Collected {:d} iCal events'.format(len(ical_events)))
 
     # retrieve the Google Calendar object itself
-    gcal_cal = service.calendars().get(calendarId=CALENDAR_ID).execute()
+    gcal_cal = service.calendars().get(calendarId=config['CALENDAR_ID']).execute()
 
     logger.info('> Processing Google Calendar events...')
     gcal_event_ids = [ev['id'] for ev in gcal_events]
@@ -214,8 +225,8 @@ if __name__ == '__main__':
             # now" to completely delete these events.
             try:
                 logger.info(u'> Deleting event "{}" from Google Calendar...'.format(gcal_event.get('summary', '<unnamed event>')))
-                service.events().delete(calendarId=CALENDAR_ID, eventId=eid).execute()
-                time.sleep(API_SLEEP_TIME)
+                service.events().delete(calendarId=config['CALENDAR_ID'], eventId=eid).execute()
+                time.sleep(config['API_SLEEP_TIME'])
             except googleapiclient.errors.HttpError:
                 pass # event already marked as deleted
         else:
@@ -257,15 +268,15 @@ if __name__ == '__main__':
 
                 gcal_event['summary'] = ical_event.summary
                 gcal_event['description'] = ical_event.description
-                if FILES:
+                if config['FILES']:
                     url_feed = 'https://www.google.com'
                 else:
-                    url_feed = ICAL_FEED
+                    url_feed = config['ICAL_FEED']
                 gcal_event['source'] = {'title': 'imported from ical_to_gcal_sync.py', 'url': url_feed}
                 gcal_event['location'] = ical_event.location
 
-                service.events().update(calendarId=CALENDAR_ID, eventId=eid, body=gcal_event).execute()
-                time.sleep(API_SLEEP_TIME)
+                service.events().update(calendarId=config['CALENDAR_ID'], eventId=eid, body=gcal_event).execute()
+                time.sleep(config['API_SLEEP_TIME'])
 
     # now add any iCal events not already in the Google Calendar 
     logger.info('> Processing iCal events...')
@@ -295,8 +306,9 @@ if __name__ == '__main__':
             logger.info('Adding iCal event called "{}", starting {}'.format(ical_event.summary, gcal_event['start']))
 
             try:
-                time.sleep(API_SLEEP_TIME)
-                service.events().insert(calendarId=CALENDAR_ID, body=gcal_event).execute()
+                time.sleep(config['API_SLEEP_TIME'])
+                service.events().insert(calendarId=config['CALENDAR_ID'], body=gcal_event).execute()
             except:
-                time.sleep(API_SLEEP_TIME)
-                service.events().update(calendarId=CALENDAR_ID, eventId=gcal_event['id'], body=gcal_event).execute()
+                time.sleep(config['API_SLEEP_TIME'])
+                service.events().update(calendarId=config['CALENDAR_ID'], eventId=gcal_event['id'], body=gcal_event).execute()
+                


### PR DESCRIPTION
## config file loading changes
The first commit in this PR changes how config is loaded so it can still be Python code, but loaded from an arbitrary file (default to `config.py`) using an environment variable. This allows for syncing multiple calendars with different setups, easily. 

However, this structurally changes the code from using`from config import CONFIG_VAR` with the config vars as first-class variables, to `config` being a dict, accessed via `config['CONFIG_VAR']`. So this changes enough that all of the subsequent commits are affected by this one commit. Hence all combined into a single PR.

This setup should be compatible with existing configs, and doesn't depend on the new config values being present.

Config loading approach is based on https://beepb00p.xyz/configs-suck.html#real_language - I'm not beholden to any particular method, I just want to be able to sync multiple calendars, and have different pre-processor rules for each one. So important is to have the ability to define a Python function in the config file.

## pre-processor (change/skip) events

Allows for defining a function in `config.py` to edit calendar entries before syncing with Google Calendar or skip individual entries. So do things like change summaries/descriptions, fix times issues, change an event to all-day, skip boring entries from being synced at all.

``` python
import icalevents
def EVENT_PREPROCESSOR(ev: icalevents.icalparser.Event) -> bool:
    from datetime import timedelta

    # Skip Bob's out of office messages
    if ev.summary == "Bob OOO":
        return False

    # Skip gaming events when we're playing Monopoly
    if ev.summary == "Gaming" and "Monopoly" in ev.description:
        return False

    # convert fire drill events to all-day events
    if ev.summary == "Fire Drill":
        ev.all_day = True
        ev.start = ev.start.replace(hour=0, minute=0, second=0)
        ev.end = ev.start + timedelta(days=1)

    # include all other entries
    return True
```

## Other changes

- **[config] allow for syncing X days in the past**, rather than just syncing today forward
- **[config] allow for restoring deleted gcal entries** - made this a config defaulting to False, in case people rely on this not restoring deleted entries - which is an understandable use-case for just pulling new/updated entries in, but wanting to hide specific entries by deleting them in GCal
- **[bug] skip re-deleting an already deleted entry** (just quiets log messages)
- **[config] allow for logging to stderr** - just leave the log file variable blank (my cron tool stores output for each run, so I prefer to just log to console)