### PR TITLE
Multi calendar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I've been running this script on an RPi as a cronjob and it's working well for m
 
 Some brief instructions:
 1. Copy `config.py.example` to a new file `config.py` or a custom file (see *Multiple Configurations* below)
-2. Set `ICAL_FEEDs` to the URL of the iCal feed you want to sync events from. If the feed is passowrd protected set also the variables `ICAL_FEED_USER` and `ICAL_FEED_PASS`.
+2. Set `ICAL_FEEDS` to the URL of the iCal feed you want to sync events from. If the feed is passowrd protected set also the variables `ICAL_FEED_USER` and `ICAL_FEED_PASS`.
 3. Set `CALENDAR_ID` to the ID of the Google Calendar instance you want to insert events into. You can set it to `primary` to use the default main calendar, or create a new secondary calendar (in which case you can find the ID on the settings page, of the form `longID@group.calendar.google.com`).
 4. `pip install -r requirements.txt`
 5. Go through the process of registering an app in the Google Calendar API dashboard in order to obtain the necessary API credentials. This process is described at https://developers.google.com/google-apps/calendar/quickstart/python - rename the downloaded file to `ical_to_gcal_sync_client_secret.json` and place it in the same location as the script. 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,18 @@ I've been running this script on an RPi as a cronjob and it's working well for m
 
 Some brief instructions:
 1. Copy `config.py.example` to a new file `config.py` or a custom file (see *Multiple Configurations* below)
-2. Set `ICAL_FEED` to the URL of the iCal feed you want to sync events from. If the feed is passowrd protected set also the variables `ICAL_FEED_USER` and `ICAL_FEED_PASS`.
+2. Set `ICAL_FEEDs` to the URL of the iCal feed you want to sync events from. If the feed is passowrd protected set also the variables `ICAL_FEED_USER` and `ICAL_FEED_PASS`.
 3. Set `CALENDAR_ID` to the ID of the Google Calendar instance you want to insert events into. You can set it to `primary` to use the default main calendar, or create a new secondary calendar (in which case you can find the ID on the settings page, of the form `longID@group.calendar.google.com`).
 4. `pip install -r requirements.txt`
-5. Go through the process of registering an app in the Google Calendar API dashboard in order to obtain the necessary API credentials. This process is described at https://developers.google.com/google-apps/calendar/quickstart/python - rename the downloaded file to ical_to_gcal_sync_client_secret.json and place it in the same location as the script. 
-6. Run the script. This should trigger the OAuth2 authentication process and prompt you to allow the app you created in step 4 to access your calendars. If successful it should store the credentials in ical_to_gcal_sync.json.
+5. Go through the process of registering an app in the Google Calendar API dashboard in order to obtain the necessary API credentials. This process is described at https://developers.google.com/google-apps/calendar/quickstart/python - rename the downloaded file to `ical_to_gcal_sync_client_secret.json` and place it in the same location as the script. 
+6. Run the script. This should trigger the OAuth2 authentication process and prompt you to allow the app you created in step 4 to access your calendars. If successful it should store the credentials in `ical_to_gcal_sync.json`.
 7. Subsequent runs of the script should not require any further interaction unless the credentials are invalidated/changed.
 
 ## Multiple Configurations / Alternate Config Location
 
 If you want to specify an alternate location for the config.py file, use the environment variable CONFIG_PATH:
 
-```
+```bash
 CONFIG_PATH='/path/to/my-custom-config.py' python ical_to_gcal_sync.py
 ```
 
@@ -32,7 +32,7 @@ function to rewrite or even skip events from being synced to the Google Calendar
 
 Some example rewrite rules:
 
-``` python
+```python
 import icalevents
 def EVENT_PREPROCESSOR(ev: icalevents.icalparser.Event) -> bool:
     from datetime import timedelta

--- a/config.py.example
+++ b/config.py.example
@@ -1,24 +1,34 @@
-# The iCal feed URL for the events that should be synced to the Google Calendar.
+# iCal feeds. More than one feed can be specified.
+#
+# 'source': The iCal feed URL for the events that should be synced to the Google Calendar.
 # Note that the syncing is one-way only.
-# If FILES is True then ICAL_FEED is the path to a folder full of ics files.
-ICAL_FEED = ''
-FILES = False
+#
+# 'destination': The ID of the calendar to use for iCal events, should be of the form
+# 'ID@group.calendar.google.com', check the calendar settings page to find it.
+# All calendars should be writable with the same google credenatials
+# (can also be 'primary' to use the default calendar)
+#
+# 'files': If it is True then 'source' is the path to a folder full of ics files.
+#
+#  Feeds can be of mixed types
 
-# Authentication information for the iCalendar feed
+ICAL_FEEDS = [
+    {'source': '<ICAL URL OR DIRECTORY PATH>', 'destination': '<GOOGLE CAL ID>', 'files': False},
+#   ...
+]
+
+# Authentication information for the ical feeds.
+# The same credentials are used for all feeds where 'files' is False
 # If the feed does not require authentication or if FILES is true, it should be left to None
 ICAL_FEED_USER = None
 ICAL_FEED_PASS = None
 
 # If the iCalendar server is using a self signed ssl certificate, certificate checking must be disabled.
+# This option applies to all feeds where 'files' is False
 # If unsure left it to True
 ICAL_FEED_VERIFY_SSL_CERT = True
 
-# the ID of the calendar to use for iCal events, should be of the form
-# 'ID@group.calendar.google.com', check the calendar settings page to find it.
-# (can also be 'primary' to use the default calendar)
-CALENDAR_ID = '<GOOGLE_CALENDAR_ID@group.calendar.google.com>'
-
-# must use the OAuth scope that allows write access
+# Must use the OAuth scope that allows write access
 SCOPES = 'https://www.googleapis.com/auth/calendar'
 
 # API secret stored in this file

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -9,6 +9,7 @@ import os
 
 import googleapiclient
 import arrow
+from googleapiclient import errors
 from icalevents.icalevents import events
 from dateutil.tz import gettz
 
@@ -33,7 +34,7 @@ logger.addHandler(handler)
 
 DEFAULT_TIMEDELTA = timedelta(days=365)
 
-def get_current_events_from_files():
+def get_current_events_from_files(path):
     
     """Retrieves data from iCal files.  Assumes that the files are all
     *.ics files located in a single directory.
@@ -45,17 +46,17 @@ def get_current_events_from_files():
     from glob import glob
     from os.path import join
 
-    event_ics = glob(join(config['ICAL_FEED'], '*.ics'))
+    event_ics = glob(join(path, '*.ics'))
 
-    logger.debug('> Found {} local .ics files in {}'.format(len(event_ics), join(config['ICAL_FEED'], '*.ics')))
+    logger.debug('> Found {} local .ics files in {}'.format(len(event_ics), join(path, '*.ics')))
     if len(event_ics) > 0:
         ics = event_ics[0]
         logger.debug('> Loading file {}'.format(ics))
-        cal = get_current_events(ics)
+        cal = get_current_events(feed_url_or_path=ics, files=True)
         logger.debug('> Found {} new events'.format(len(cal)))
         for ics in event_ics[1:]:
             logger.debug('> Loading file {}'.format(ics))
-            evt = get_current_events(ics)
+            evt = get_current_events(feed_url_or_path=ics, files=True)
             if len(evt) > 0:
                 cal.extend(evt)
             logger.debug('> Found {} new events'.format(len(evt)))
@@ -63,7 +64,7 @@ def get_current_events_from_files():
     else:
         return None
 
-def get_current_events(feed):
+def get_current_events(feed_url_or_path, files):
     """Retrieves data from iCal iCal feed and returns an ics.Calendar object 
     containing the parsed data.
 
@@ -79,8 +80,8 @@ def get_current_events(feed):
         events_end += timedelta(days=config['ICAL_DAYS_TO_SYNC'])
 
     try:
-        if config['FILES']:
-            cal = events(file=feed, end=events_end)
+        if files:
+            cal = events(file=feed_url_or_path, end=events_end)
         else:
             # directly configure http connection object to set ssl and authentication parameters
             http_conn = Http(cache='.cache', disable_ssl_certificate_validation=not config.get('ICAL_FEED_VERIFY_SSL_CERT', True))
@@ -89,14 +90,14 @@ def get_current_events(feed):
                 # credentials used for every connection
                 http_conn.add_credentials(name=config.get('ICAL_FEED_USER'), password=config.get('ICAL_FEED_PASS'))
 
-            cal = events(feed, start=datetime.now()-timedelta(days=config.get('PAST_DAYS_TO_SYNC', 0)), end=events_end, http=http_conn)
+            cal = events(feed_url_or_path, start=datetime.now()-timedelta(days=config.get('PAST_DAYS_TO_SYNC', 0)), end=events_end, http=http_conn)
     except Exception as e:
         logger.error('> Error retrieving iCal data ({})'.format(e))
         return None
 
     return cal
 
-def get_gcal_events(service, from_time=None):
+def get_gcal_events(calendar_id, service, from_time=None):
     """Retrieves the current set of Google Calendar events from the selected
     user calendar. If from_time is not specified, includes events from all-time.
 
@@ -110,41 +111,33 @@ def get_gcal_events(service, from_time=None):
     logger.debug('Retrieving Google Calendar events')
 
     # make an initial call, if this returns all events we don't need to do anything else,,,
-    eventsResult = service.events().list(calendarId=config['CALENDAR_ID'], 
+    events_result = service.events().list(calendarId=calendar_id,
                                          timeMin=from_time, 
                                          singleEvents=True, 
                                          orderBy='startTime', 
                                          showDeleted=True).execute()
 
-    events = eventsResult.get('items', [])
+    events = events_result.get('items', [])
     # if nextPageToken is NOT in the dict, this should be everything
-    if 'nextPageToken' not in eventsResult:
+    if 'nextPageToken' not in events_result:
         logger.info('> Found {:d} upcoming events in Google Calendar (single page)'.format(len(events)))
         return events
 
     # otherwise keep calling the method, passing back the nextPageToken each time
-    while 'nextPageToken' in eventsResult:
-        token = eventsResult['nextPageToken']
-        eventsResult = service.events().list(calendarId=config['CALENDAR_ID'], 
+    while 'nextPageToken' in events_result:
+        token = events_result['nextPageToken']
+        events_result = service.events().list(calendarId=calendar_id,
                                              timeMin=from_time, 
                                              pageToken=token, 
                                              singleEvents=True, 
                                              orderBy='startTime', 
                                              showDeleted=True).execute()
-        newevents = eventsResult.get('items', [])
+        newevents = events_result.get('items', [])
         events.extend(newevents)
         logger.debug('> Found {:d} events on new page, {:d} total'.format(len(newevents), len(events)))
     
     logger.info('> Found {:d} upcoming events in Google Calendar (multi page)'.format(len(events)))
     return events
-
-def delete_all_events(service):
-    for gc in get_gcal_events(service, from_time=None):
-        try:
-            service.events().delete(calendarId=config['CALENDAR_ID'], eventId=gc['id']).execute()
-            time.sleep(config['API_SLEEP_TIME'])
-        except googleapiclient.errors.HttpError:
-            pass # event already marked as deleted
 
 def get_gcal_datetime(py_datetime, gcal_timezone):
     py_datetime = py_datetime.astimezone(gettz(gcal_timezone))
@@ -167,10 +160,10 @@ def create_id(uid, begintime, endtime):
     return re.sub('[^{}]'.format(allowed_chars), '', uid.lower()) + str(arrow.get(begintime).timestamp) + str(arrow.get(endtime).timestamp)
 
 if __name__ == '__main__':
-    mandatory_configs = ['CALENDAR_ID', 'CREDENTIAL_PATH', 'ICAL_FEED', 'APPLICATION_NAME']
+    mandatory_configs = ['CREDENTIAL_PATH', 'ICAL_FEEDS', 'APPLICATION_NAME']
     for mandatory in mandatory_configs:
         if not config.get(mandatory) or config[mandatory][0] == '<':
-            logger.error("Must specify a non-blank value for %s in the config file" % ( mandatory ) )
+            logger.error("Must specify a non-blank value for %s in the config file" % mandatory)
             sys.exit(1)
 
     # setting up Google Calendar API for use
@@ -180,173 +173,178 @@ if __name__ == '__main__':
     # dateime instance representing the start of the current day (UTC)
     today = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
 
-    # retrieve events from Google Calendar, starting from beginning of current day
-    logger.info('> Retrieving events from Google Calendar')
-    gcal_events = get_gcal_events(service, from_time=(today-timedelta(days=config.get('PAST_DAYS_TO_SYNC',0))).isoformat())
+    for feed in config.get('ICAL_FEEDS'):
+        logger.info('> Processing source %s' % feed['source'])
 
-    # retrieve events from the iCal feed
-    if config['FILES']:
-        logger.info('> Retrieving events from local folder')
-        ical_cal = get_current_events_from_files()
-    else:
-        logger.info('> Retrieving events from iCal feed')
-        ical_cal = get_current_events(config['ICAL_FEED'])
+        # retrieve events from Google Calendar, starting from beginning of current day
+        logger.info('> Retrieving events from Google Calendar')
+        gcal_events = get_gcal_events(calendar_id=feed['destination'], service=service, from_time=(today-timedelta(days=config.get('PAST_DAYS_TO_SYNC', 0))).isoformat())
 
-    if ical_cal is None:
-        sys.exit(-1)
-
-    # convert iCal event list into a dict indexed by (converted) iCal UID
-    ical_events = {}
-
-    for ev in ical_cal:
-        # explicitly set any events with no timezone to use UTC (icalevents
-        # doesn't seem to do this automatically like ics.py)
-        if ev.start.tzinfo is None:
-            ev.start = ev.start.replace(tzinfo=timezone.utc)
-        if ev.end is not None and ev.end.tzinfo is None:
-            ev.end = ev.end.replace(tzinfo=timezone.utc)
-
-        try:
-            if 'EVENT_PREPROCESSOR' in config:
-                keep = config['EVENT_PREPROCESSOR'](ev)
-                if not keep: 
-                    logger.debug("Skipping event %s - EVENT_PREPROCESSOR returned false" % (str(ev)))
-                    continue
-
-        except Exception as ex:
-            logger.error("Error processing entry (%s) - leaving as-is" % str(ev))
-
-        ical_events[create_id(ev.uid, ev.start, ev.end)] = ev
-
-    logger.debug('> Collected {:d} iCal events'.format(len(ical_events)))
-
-    # retrieve the Google Calendar object itself
-    gcal_cal = service.calendars().get(calendarId=config['CALENDAR_ID']).execute()
-
-    logger.info('> Processing Google Calendar events...')
-    gcal_event_ids = [ev['id'] for ev in gcal_events]
-
-    # first check the set of Google Calendar events against the list of iCal
-    # events. Any events in Google Calendar that are no longer in iCal feed
-    # get deleted. Any events still present but with changed start/end times
-    # get updated.
-    for gcal_event in gcal_events:
-        eid = gcal_event['id']
-
-        if eid not in ical_events:
-            # if a gcal event has been deleted from iCal, also delete it from gcal.
-            # Apparently calling delete() only marks an event as "deleted" but doesn't
-            # remove it from the calendar, so it will continue to stick around. 
-            # If you keep seeing messages about events being deleted here, you can
-            # try going to the Google Calendar site, opening the options menu for 
-            # your calendar, selecting "View bin" and then clicking "Empty bin 
-            # now" to completely delete these events.
-            try:
-                # already marked as deleted, so it's in the "trash" or "bin"
-                if gcal_event['status'] == 'cancelled': continue
-
-                logger.info(u'> Deleting event "{}" from Google Calendar...'.format(gcal_event.get('summary', '<unnamed event>')))
-                service.events().delete(calendarId=config['CALENDAR_ID'], eventId=eid).execute()
-                time.sleep(config['API_SLEEP_TIME'])
-            except googleapiclient.errors.HttpError:
-                pass # event already marked as deleted
+        # retrieve events from the iCal feed
+        if feed['files']:
+            logger.info('> Retrieving events from local folder')
+            ical_cal = get_current_events_from_files(feed['source'])
         else:
-            ical_event = ical_events[eid]
-            gcal_begin = arrow.get(gcal_event['start'].get('dateTime', gcal_event['start'].get('date')))
-            gcal_end = arrow.get(gcal_event['end'].get('dateTime', gcal_event['end'].get('date')))
+            logger.info('> Retrieving events from iCal feed')
+            ical_cal = get_current_events(feed_url_or_path=feed['source'], files=False)
 
-            gcal_has_location = bool(gcal_event.get('location'))
-            ical_has_location = bool(ical_event.location)
+        if ical_cal is None:
+            sys.exit(-1)
 
-            gcal_has_description = 'description' in gcal_event
-            ical_has_description = ical_event.description is not None
+        # convert iCal event list into a dict indexed by (converted) iCal UID
+        ical_events = {}
 
-            # event name can be left unset, in which case there's no summary field
-            gcal_name = gcal_event.get('summary', None)
-            log_name = '<unnamed event>' if gcal_name is None else gcal_name
+        for ev in ical_cal:
+            # explicitly set any events with no timezone to use UTC (icalevents
+            # doesn't seem to do this automatically like ics.py)
+            if ev.start.tzinfo is None:
+                ev.start = ev.start.replace(tzinfo=timezone.utc)
+            if ev.end is not None and ev.end.tzinfo is None:
+                ev.end = ev.end.replace(tzinfo=timezone.utc)
 
-            times_differ = gcal_begin != ical_event.start or gcal_end != ical_event.end
-            titles_differ = gcal_name != ical_event.summary
-            locs_differ = gcal_has_location != ical_has_location and gcal_event.get('location') != ical_event.location
-            descs_differ = gcal_has_description != ical_has_description and (gcal_event.get('description') != ical_event.description)
+            try:
+                if 'EVENT_PREPROCESSOR' in config:
+                    keep = config['EVENT_PREPROCESSOR'](ev)
+                    if not keep:
+                        logger.debug("Skipping event %s - EVENT_PREPROCESSOR returned false" % (str(ev)))
+                        continue
 
-            needs_undelete = config.get('RESTORE_DELETED_EVENTS', False) and gcal_event['status'] == 'cancelled'
-            
-            changes = []
-            if times_differ: changes.append("start/end times")
-            if titles_differ: changes.append("titles")
-            if locs_differ: changes.append("locations")
-            if descs_differ: changes.append("descriptions")
-            if needs_undelete: changes.append("undeleted")
+            except Exception as ex:
+                logger.error("Error processing entry (%s) - leaving as-is" % str(ev))
 
-            # check if the iCal event has a different: start/end time, name, location,
-            # or description, and if so sync the changes to the GCal event
-            if needs_undelete or times_differ or titles_differ or locs_differ or descs_differ:
-                logger.info(u'> Updating event "{}" due to changes: {}'.format(log_name, ", ".join(changes)))
-                delta = ical_event.end - ical_event.start
-                # all-day events handled slightly differently
-                # TODO multi-day events?
-                if delta.days >= 1:
-                    gcal_event['start'] = get_gcal_date(ical_event.start)
-                    gcal_event['end'] = get_gcal_date(ical_event.end)
-                else:
-                    gcal_event['start'] = get_gcal_datetime(ical_event.start, gcal_cal['timeZone'])
-                    if ical_event.end is not None:
-                        gcal_event['end']   = get_gcal_datetime(ical_event.end, gcal_cal['timeZone'])
+            ical_events[create_id(ev.uid, ev.start, ev.end)] = ev
 
-                # if the event was deleted, the status will be 'cancelled' - this restores it
-                gcal_event['status'] = 'confirmed'
+        logger.debug('> Collected {:d} iCal events'.format(len(ical_events)))
 
+        # retrieve the Google Calendar object itself
+        gcal_cal = service.calendars().get(calendarId=feed['destination']).execute()
+
+        logger.info('> Processing Google Calendar events...')
+        gcal_event_ids = [ev['id'] for ev in gcal_events]
+
+        # first check the set of Google Calendar events against the list of iCal
+        # events. Any events in Google Calendar that are no longer in iCal feed
+        # get deleted. Any events still present but with changed start/end times
+        # get updated.
+        for gcal_event in gcal_events:
+            eid = gcal_event['id']
+
+            if eid not in ical_events:
+                # if a gcal event has been deleted from iCal, also delete it from gcal.
+                # Apparently calling delete() only marks an event as "deleted" but doesn't
+                # remove it from the calendar, so it will continue to stick around.
+                # If you keep seeing messages about events being deleted here, you can
+                # try going to the Google Calendar site, opening the options menu for
+                # your calendar, selecting "View bin" and then clicking "Empty bin
+                # now" to completely delete these events.
+                try:
+                    # already marked as deleted, so it's in the "trash" or "bin"
+                    if gcal_event['status'] == 'cancelled': continue
+
+                    logger.info(u'> Deleting event "{}" from Google Calendar...'.format(gcal_event.get('summary', '<unnamed event>')))
+                    service.events().delete(calendarId=feed['destination'], eventId=eid).execute()
+                    time.sleep(config['API_SLEEP_TIME'])
+                except googleapiclient.errors.HttpError:
+                    pass # event already marked as deleted
+            else:
+                ical_event = ical_events[eid]
+                gcal_begin = arrow.get(gcal_event['start'].get('dateTime', gcal_event['start'].get('date')))
+                gcal_end = arrow.get(gcal_event['end'].get('dateTime', gcal_event['end'].get('date')))
+
+                gcal_has_location = bool(gcal_event.get('location'))
+                ical_has_location = bool(ical_event.location)
+
+                gcal_has_description = 'description' in gcal_event
+                ical_has_description = ical_event.description is not None
+
+                # event name can be left unset, in which case there's no summary field
+                gcal_name = gcal_event.get('summary', None)
+                log_name = '<unnamed event>' if gcal_name is None else gcal_name
+
+                times_differ = gcal_begin != ical_event.start or gcal_end != ical_event.end
+                titles_differ = gcal_name != ical_event.summary
+                locs_differ = gcal_has_location != ical_has_location and gcal_event.get('location') != ical_event.location
+                descs_differ = gcal_has_description != ical_has_description and (gcal_event.get('description') != ical_event.description)
+
+                needs_undelete = config.get('RESTORE_DELETED_EVENTS', False) and gcal_event['status'] == 'cancelled'
+
+                changes = []
+                if times_differ: changes.append("start/end times")
+                if titles_differ: changes.append("titles")
+                if locs_differ: changes.append("locations")
+                if descs_differ: changes.append("descriptions")
+                if needs_undelete: changes.append("undeleted")
+
+                # check if the iCal event has a different: start/end time, name, location,
+                # or description, and if so sync the changes to the GCal event
+                if needs_undelete or times_differ or titles_differ or locs_differ or descs_differ:
+                    logger.info(u'> Updating event "{}" due to changes: {}'.format(log_name, ", ".join(changes)))
+                    delta = ical_event.end - ical_event.start
+                    # all-day events handled slightly differently
+                    # TODO multi-day events?
+                    if delta.days >= 1:
+                        gcal_event['start'] = get_gcal_date(ical_event.start)
+                        gcal_event['end'] = get_gcal_date(ical_event.end)
+                    else:
+                        gcal_event['start'] = get_gcal_datetime(ical_event.start, gcal_cal['timeZone'])
+                        if ical_event.end is not None:
+                            gcal_event['end']   = get_gcal_datetime(ical_event.end, gcal_cal['timeZone'])
+
+                    # if the event was deleted, the status will be 'cancelled' - this restores it
+                    gcal_event['status'] = 'confirmed'
+
+                    gcal_event['summary'] = ical_event.summary
+                    gcal_event['description'] = ical_event.description
+                    if feed['files']:
+                        url_feed = 'https://events.from.ics.files.com'
+                    else:
+                        url_feed = feed['source']
+                    gcal_event['source'] = {'title': 'Imported from ical_to_gcal_sync.py', 'url': url_feed}
+                    gcal_event['location'] = ical_event.location
+
+                    service.events().update(calendarId=feed['destination'], eventId=eid, body=gcal_event).execute()
+                    time.sleep(config['API_SLEEP_TIME'])
+
+        # now add any iCal events not already in the Google Calendar
+        logger.info('> Processing iCal events...')
+        for ical_id, ical_event in ical_events.items():
+            if ical_id not in gcal_event_ids:
+                gcal_event = {}
                 gcal_event['summary'] = ical_event.summary
+                gcal_event['id'] = ical_id
                 gcal_event['description'] = ical_event.description
-                if config['FILES']:
+                if feed['files']:
                     url_feed = 'https://events.from.ics.files.com'
                 else:
-                    url_feed = config['ICAL_FEED']
+                    url_feed = feed['source']
                 gcal_event['source'] = {'title': 'Imported from ical_to_gcal_sync.py', 'url': url_feed}
                 gcal_event['location'] = ical_event.location
 
-                service.events().update(calendarId=config['CALENDAR_ID'], eventId=eid, body=gcal_event).execute()
-                time.sleep(config['API_SLEEP_TIME'])
 
-    # now add any iCal events not already in the Google Calendar 
-    logger.info('> Processing iCal events...')
-    for ical_id, ical_event in ical_events.items():
-        if ical_id not in gcal_event_ids:
-            gcal_event = {}
-            gcal_event['summary'] = ical_event.summary
-            gcal_event['id'] = ical_id
-            gcal_event['description'] = ical_event.description
-            if config['FILES']:
-                url_feed = 'https://events.from.ics.files.com'
-            else:
-                url_feed = config['ICAL_FEED']
-            gcal_event['source'] = {'title': 'Imported from ical_to_gcal_sync.py', 'url': url_feed}
-            gcal_event['location'] = ical_event.location
+                # check if no time specified in iCal, treat as all day event if so
+                delta = ical_event.end - ical_event.start
+                # TODO multi-day events?
+                if delta.days >= 1:
+                    gcal_event['start'] = get_gcal_date(ical_event.start)
+                    logger.info(u'iCal all-day event {} to be added at {}'.format(ical_event.summary, ical_event.start))
+                    if ical_event.end is not None:
+                        gcal_event['end'] = get_gcal_date(ical_event.end)
+                else:
+                    gcal_event['start'] = get_gcal_datetime(ical_event.start, gcal_cal['timeZone'])
+                    logger.info(u'iCal event {} to be added at {}'.format(ical_event.summary, ical_event.start))
+                    if ical_event.end is not None:
+                        gcal_event['end'] = get_gcal_datetime(ical_event.end, gcal_cal['timeZone'])
 
+                logger.info('Adding iCal event called "{}", starting {}'.format(ical_event.summary, gcal_event['start']))
 
-            # check if no time specified in iCal, treat as all day event if so
-            delta = ical_event.end - ical_event.start
-            # TODO multi-day events?
-            if delta.days >= 1:
-                gcal_event['start'] = get_gcal_date(ical_event.start)
-                logger.info(u'iCal all-day event {} to be added at {}'.format(ical_event.summary, ical_event.start))
-                if ical_event.end is not None:
-                    gcal_event['end'] = get_gcal_date(ical_event.end)
-            else:
-                gcal_event['start'] = get_gcal_datetime(ical_event.start, gcal_cal['timeZone'])
-                logger.info(u'iCal event {} to be added at {}'.format(ical_event.summary, ical_event.start))
-                if ical_event.end is not None:
-                    gcal_event['end'] = get_gcal_datetime(ical_event.end, gcal_cal['timeZone'])
-
-            logger.info('Adding iCal event called "{}", starting {}'.format(ical_event.summary, gcal_event['start']))
-
-            try:
-                time.sleep(config['API_SLEEP_TIME'])
-                service.events().insert(calendarId=config['CALENDAR_ID'], body=gcal_event).execute()
-            except:
-                time.sleep(config['API_SLEEP_TIME'])
                 try:
-                    service.events().update(calendarId=config['CALENDAR_ID'], eventId=gcal_event['id'], body=gcal_event).execute()
-                except Exception as ex:
-                    logger.error("Error updating: %s (%s)" % ( gcal_event['id'], ex ) )
+                    time.sleep(config['API_SLEEP_TIME'])
+                    service.events().insert(calendarId=feed['destination'], body=gcal_event).execute()
+                except Exception:
+                    time.sleep(config['API_SLEEP_TIME'])
+                    try:
+                        service.events().update(calendarId=feed['destination'], eventId=gcal_event['id'], body=gcal_event).execute()
+                    except Exception as ex:
+                        logger.error("Error updating: %s (%s)" % ( gcal_event['id'], ex ) )
+
+        logger.info('> Processing of source %s completed' % feed['source'])

--- a/ical_to_gcal_sync.py
+++ b/ical_to_gcal_sync.py
@@ -84,7 +84,7 @@ def get_current_events(feed_url_or_path, files):
             cal = events(file=feed_url_or_path, end=events_end)
         else:
             # directly configure http connection object to set ssl and authentication parameters
-            http_conn = Http(cache='.cache', disable_ssl_certificate_validation=not config.get('ICAL_FEED_VERIFY_SSL_CERT', True))
+            http_conn = Http(disable_ssl_certificate_validation=not config.get('ICAL_FEED_VERIFY_SSL_CERT', True))
 
             if config.get('ICAL_FEED_USER') and config.get('ICAL_FEED_PASS'):
                 # credentials used for every connection


### PR DESCRIPTION
This is another PR to add multi calendar support in the same config file.

The new config works as follows:

~~~python
ICAL_FEEDS = [
    {'source': '<ICAL URL OR DIRECTORY PATH 1>', 'destination': '<GOOGLE CAL ID 1>', 'files': False},
    {'source': '<ICAL URL OR DIRECTORY PATH 2>', 'destination': '<GOOGLE CAL ID 2>', 'files': False},
    {'source': '<ICAL URL OR DIRECTORY PATH 3>', 'destination': '<GOOGLE CAL ID 3>', 'files': False},
    ...
]
~~~

I have made a separate PR from the authentication one to allow for selective merge.

Also notice that this PR changes the format of the config file, so it is not backward compatible. It can be made backward compatible with a little more effort. If needed to merge i can add it.
